### PR TITLE
Does not shutdown on octopi image, on pi 3 b.

### DIFF
--- a/octoprint_shutdownbuttonledbuzzer/__init__.py
+++ b/octoprint_shutdownbuttonledbuzzer/__init__.py
@@ -53,7 +53,7 @@ class ShutdownButtonLEDBuzzerPlugin(
     HOLD_TIME_S = 1
     MID_TONE = "B4"  # Client input max and min values depend on this
     OCTAVES = 3  # Client input max and min values depend on this
-    PI_SHUTDOWN_COMMAND = "shutdown -h now"
+    PI_SHUTDOWN_COMMAND = "sudo shutdown -h now"
     I2C_STATUS_COMMAND = "raspi-config nonint get_i2c"
     SPI_STATUS_COMMAND = "raspi-config nonint get_spi"
     SERVICE_ENABLED_OUTPUT = "0"


### PR DESCRIPTION
Hi @danieleborgo,

Thanks for the cool plugin!

The button does not shutdown the pi. I am running an official octopi image, on pi 3 b. It looks like they use sudo shutdown, and have a /etc/sudoers.d/ file to permit password-less shutdown.

I just made the small tweak. Although on my actual pi, in this plugin I used full paths to the various commands, sudo and shutdown, but in this commit, I did not.

Thank you,
Matt